### PR TITLE
Improved GtfsRealtimeAdapter to discard invalid Stop IDs

### DIFF
--- a/gtfslake-realtime.yaml
+++ b/gtfslake-realtime.yaml
@@ -18,6 +18,7 @@ caching:
 matching:
   match_against_first_stop_id: true
   match_against_stop_ids: false
+  remove_invalid_stop_ids: true
 mqtt:
   host: test.mosquitto.org
   port: 1883

--- a/gtfslake/adapter/gtfsrt.py
+++ b/gtfslake/adapter/gtfsrt.py
@@ -242,7 +242,7 @@ class GtfsRealtimeAdapter:
                                         break
 
                             # finally delete discarded stop time updates
-                            for d in deleted_stop_time_updates:
+                            for d in sorted(deleted_stop_time_updates, reverse=True):
                                 del matching_entity.trip_update.stop_time_update[d]
 
                             # if all intermediate stops matching, the whole trip matches

--- a/gtfslake/adapter/gtfsrt.py
+++ b/gtfslake/adapter/gtfsrt.py
@@ -223,7 +223,7 @@ class GtfsRealtimeAdapter:
                                     if stu.stop_sequence != 1:
                                         continue
 
-                                if stu.stop_sequence >= len(self._nominal_trips_intermediate_stops[candidate]):
+                                if stu.stop_sequence > len(self._nominal_trips_intermediate_stops[candidate]):
                                     logger.warning(f"Could not match trip {entity.trip_update.trip.trip_id} due to nominal stop number mismatch")
                                     intermediate_stops_matching = False
                                     break


### PR DESCRIPTION
GtfsRealtimeAdapter has been improved to discard invalid stop IDs if configured. Set the property `matching.remove_invalid_stop_ids` in realtime configuration to enable this setting.